### PR TITLE
feat: add pagination to all get-all endpoints

### DIFF
--- a/controllers/adventures.js
+++ b/controllers/adventures.js
@@ -4,12 +4,24 @@ const Park = require("../models/Park");
 
 const getAllAdventures = async (req, res) => {
   /* #swagger.tags = ['Adventures']
-     #swagger.description = 'Retrieve all adventures, optionally filtered by parkId'
+     #swagger.description = 'Retrieve all adventures with pagination, optionally filtered by parkId'
      #swagger.parameters['parkId'] = {
         in: 'query',
         description: 'Optional park ObjectId used to filter adventures',
         required: false,
         type: 'string'
+     }
+     #swagger.parameters['page'] = {
+        in: 'query',
+        description: 'Page number (default: 1)',
+        required: false,
+        type: 'integer'
+     }
+     #swagger.parameters['limit'] = {
+        in: 'query',
+        description: 'Number of results per page (default: 10)',
+        required: false,
+        type: 'integer'
      }
   */
   try {
@@ -34,8 +46,22 @@ const getAllAdventures = async (req, res) => {
       }
     }
 
-    const adventures = await Adventure.find(filter);
-    return res.status(200).json(adventures);
+    const page = Math.max(1, parseInt(req.query.page) || 1);
+    const limit = Math.max(1, parseInt(req.query.limit) || 10);
+    const skip = (page - 1) * limit;
+
+    const [adventures, total] = await Promise.all([
+      Adventure.find(filter).skip(skip).limit(limit),
+      Adventure.countDocuments(filter)
+    ]);
+
+    return res.status(200).json({
+      data: adventures,
+      page,
+      limit,
+      total,
+      totalPages: Math.ceil(total / limit)
+    });
   } catch (error) {
     return res.status(500).json({
       success: false,

--- a/controllers/alerts.js
+++ b/controllers/alerts.js
@@ -3,12 +3,24 @@ const Alert = require("../models/Alert");
 
 const getAllAlerts = async (req, res) => {
   /* #swagger.tags = ['Alerts']
-        #swagger.description = 'Retrieve all alerts, optionally filtered by parkId'
+        #swagger.description = 'Retrieve all alerts with pagination, optionally filtered by parkId'
         #swagger.parameters['parkId'] = {
           in: 'query',
           description: 'Optional park ObjectId used to filter alerts',
           required: false,
           type: 'string'
+       }
+       #swagger.parameters['page'] = {
+          in: 'query',
+          description: 'Page number (default: 1)',
+          required: false,
+          type: 'integer'
+       }
+       #swagger.parameters['limit'] = {
+          in: 'query',
+          description: 'Number of results per page (default: 10)',
+          required: false,
+          type: 'integer'
        }
     */
   try {
@@ -22,8 +34,22 @@ const getAllAlerts = async (req, res) => {
       filter.parkId = req.query.parkId;
     }
 
-    const alerts = await Alert.find(filter);
-    return res.status(200).json(alerts);
+    const page = Math.max(1, parseInt(req.query.page) || 1);
+    const limit = Math.max(1, parseInt(req.query.limit) || 10);
+    const skip = (page - 1) * limit;
+
+    const [alerts, total] = await Promise.all([
+      Alert.find(filter).skip(skip).limit(limit),
+      Alert.countDocuments(filter)
+    ]);
+
+    return res.status(200).json({
+      data: alerts,
+      page,
+      limit,
+      total,
+      totalPages: Math.ceil(total / limit)
+    });
   } catch (error) {
     return res.status(500).json({
       error: error.message || "An error occurred while fetching alerts."

--- a/controllers/campgrounds.js
+++ b/controllers/campgrounds.js
@@ -4,12 +4,24 @@ const Park = require("../models/Park");
 
 const getAllCampgrounds = async (req, res) => {
   /* #swagger.tags = ['Campgrounds']
-       #swagger.description = 'Retrieve all campgrounds, optionally filtered by parkId'
+       #swagger.description = 'Retrieve all campgrounds with pagination, optionally filtered by parkId'
        #swagger.parameters['parkId'] = {
           in: 'query',
           description: 'Optional park ObjectId used to filter campgrounds',
           required: false,
           type: 'string'
+       }
+       #swagger.parameters['page'] = {
+          in: 'query',
+          description: 'Page number (default: 1)',
+          required: false,
+          type: 'integer'
+       }
+       #swagger.parameters['limit'] = {
+          in: 'query',
+          description: 'Number of results per page (default: 10)',
+          required: false,
+          type: 'integer'
        }
     */
   try {
@@ -34,8 +46,22 @@ const getAllCampgrounds = async (req, res) => {
       }
     }
 
-    const campgrounds = await Campground.find(filter);
-    return res.status(200).json(campgrounds);
+    const page = Math.max(1, parseInt(req.query.page) || 1);
+    const limit = Math.max(1, parseInt(req.query.limit) || 10);
+    const skip = (page - 1) * limit;
+
+    const [campgrounds, total] = await Promise.all([
+      Campground.find(filter).skip(skip).limit(limit),
+      Campground.countDocuments(filter)
+    ]);
+
+    return res.status(200).json({
+      data: campgrounds,
+      page,
+      limit,
+      total,
+      totalPages: Math.ceil(total / limit)
+    });
   } catch (error) {
     return res.status(500).json({
       success: false,

--- a/controllers/parks.js
+++ b/controllers/parks.js
@@ -1,11 +1,38 @@
 const Park = require("../models/Park");
 
 const getAll = async (req, res) => {
-  // #swagger.tags = ['Parks']
-  // #swagger.description = 'Retrieve all parks'
+  /* #swagger.tags = ['Parks']
+     #swagger.description = 'Retrieve all parks with pagination'
+     #swagger.parameters['page'] = {
+        in: 'query',
+        description: 'Page number (default: 1)',
+        required: false,
+        type: 'integer'
+     }
+     #swagger.parameters['limit'] = {
+        in: 'query',
+        description: 'Number of results per page (default: 10)',
+        required: false,
+        type: 'integer'
+     }
+  */
   try {
-    const parks = await Park.find();
-    res.status(200).json(parks);
+    const page = Math.max(1, parseInt(req.query.page) || 1);
+    const limit = Math.max(1, parseInt(req.query.limit) || 10);
+    const skip = (page - 1) * limit;
+
+    const [parks, total] = await Promise.all([
+      Park.find().skip(skip).limit(limit),
+      Park.countDocuments()
+    ]);
+
+    res.status(200).json({
+      data: parks,
+      page,
+      limit,
+      total,
+      totalPages: Math.ceil(total / limit)
+    });
   } catch (err) {
     res.status(500).json({ error: err.message || "An error occurred while fetching parks." });
   }

--- a/controllers/reviews.js
+++ b/controllers/reviews.js
@@ -1,0 +1,214 @@
+const mongoose = require("mongoose");
+const Review = require("../models/Review");
+const Park = require("../models/Park");
+
+const getAllReviews = async (req, res) => {
+  /* #swagger.tags = ['Reviews']
+     #swagger.description = 'Retrieve all reviews with pagination, optionally filtered by parkId'
+     #swagger.parameters['parkId'] = {
+       in: 'query',
+       description: 'Optional park ObjectId used to filter reviews',
+       required: false,
+       type: 'string'
+     }
+     #swagger.parameters['page'] = {
+       in: 'query',
+       description: 'Page number (default: 1)',
+       required: false,
+       type: 'integer'
+     }
+     #swagger.parameters['limit'] = {
+       in: 'query',
+       description: 'Number of results per page (default: 10)',
+       required: false,
+       type: 'integer'
+     }
+  */
+  try {
+    const filter = {};
+
+    if (req.query.parkId) {
+      if (!mongoose.Types.ObjectId.isValid(req.query.parkId)) {
+        return res.status(400).json({ error: "Invalid parkId." });
+      }
+      filter.parkId = req.query.parkId;
+    }
+
+    const page = Math.max(1, parseInt(req.query.page) || 1);
+    const limit = Math.max(1, parseInt(req.query.limit) || 10);
+    const skip = (page - 1) * limit;
+
+    const [reviews, total] = await Promise.all([
+      Review.find(filter).skip(skip).limit(limit),
+      Review.countDocuments(filter)
+    ]);
+
+    return res.status(200).json({
+      data: reviews,
+      page,
+      limit,
+      total,
+      totalPages: Math.ceil(total / limit)
+    });
+  } catch (error) {
+    return res.status(500).json({
+      error: error.message || "An error occurred while fetching reviews."
+    });
+  }
+};
+
+const getReviewById = async (req, res) => {
+  /* #swagger.tags = ['Reviews']
+     #swagger.description = 'Retrieve a single review by its ID'
+     #swagger.parameters['id'] = {
+       in: 'path',
+       description: 'Review ObjectId',
+       required: true,
+       type: 'string'
+     }
+  */
+  try {
+    const { id } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({ error: "Invalid review id." });
+    }
+
+    const review = await Review.findById(id);
+
+    if (!review) {
+      return res.status(404).json({ error: "Review not found." });
+    }
+
+    return res.status(200).json(review);
+  } catch (error) {
+    return res.status(500).json({
+      error: error.message || "An error occurred while fetching the review."
+    });
+  }
+};
+
+const createReview = async (req, res) => {
+  /* #swagger.tags = ['Reviews']
+     #swagger.description = 'Create a new review. Authentication required.'
+     #swagger.parameters['obj'] = {
+       in: 'body',
+       description: 'Review object',
+       required: true,
+       schema: {
+         "parkId": "64f1234567890abcde654321",
+         "userId": "github12345",
+         "rating": 5,
+         "title": "Breathtaking Views",
+         "comment": "One of the most beautiful places I have ever visited.",
+         "visitDate": "2025-07-20"
+       }
+     }
+  */
+  try {
+    const review = await Review.create(req.body);
+    return res.status(201).json(review);
+  } catch (error) {
+    if (error.name === "ValidationError") {
+      return res.status(400).json({ error: error.message });
+    }
+
+    if (error.name === "CastError") {
+      return res.status(400).json({ error: "Invalid data provided." });
+    }
+
+    return res.status(500).json({
+      error: error.message || "An error occurred while creating the review."
+    });
+  }
+};
+
+const updateReview = async (req, res) => {
+  /* #swagger.tags = ['Reviews']
+     #swagger.description = 'Update a review by its ID. Authentication required.'
+     #swagger.parameters['id'] = {
+       in: 'path',
+       description: 'Review ObjectId',
+       required: true,
+       type: 'string'
+     }
+     #swagger.parameters['obj'] = {
+       in: 'body',
+       description: 'Review fields to update',
+       schema: {
+         "rating": 4,
+         "title": "Updated Title",
+         "comment": "Updated comment."
+       }
+     }
+  */
+  try {
+    const { id } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({ error: "Invalid review id." });
+    }
+
+    const review = await Review.findByIdAndUpdate(id, req.body, {
+      returnDocument: "after",
+      runValidators: true
+    });
+
+    if (!review) {
+      return res.status(404).json({ error: "Review not found." });
+    }
+
+    return res.status(200).json(review);
+  } catch (error) {
+    if (error.name === "ValidationError") {
+      return res.status(400).json({ error: error.message });
+    }
+
+    if (error.name === "CastError") {
+      return res.status(400).json({ error: "Invalid data provided." });
+    }
+
+    return res.status(500).json({
+      error: error.message || "An error occurred while updating the review."
+    });
+  }
+};
+
+const deleteReview = async (req, res) => {
+  /* #swagger.tags = ['Reviews']
+     #swagger.description = 'Delete a review by its ID. Authentication required.'
+     #swagger.parameters['id'] = {
+       in: 'path',
+       description: 'Review ObjectId',
+       required: true,
+       type: 'string'
+     }
+  */
+  try {
+    const { id } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({ error: "Invalid review id." });
+    }
+
+    const review = await Review.findByIdAndDelete(id);
+
+    if (!review) {
+      return res.status(404).json({ error: "Review not found." });
+    }
+
+    return res.status(200).json({ message: "Review deleted successfully." });
+  } catch (error) {
+    return res.status(500).json({
+      error: error.message || "An error occurred while deleting the review."
+    });
+  }
+};
+
+module.exports = {
+  getAllReviews,
+  getReviewById,
+  createReview,
+  updateReview,
+  deleteReview
+};

--- a/controllers/trails.js
+++ b/controllers/trails.js
@@ -3,12 +3,24 @@ const Trail = require("../models/Trail");
 
 const getAllTrails = async (req, res) => {
   /* #swagger.tags = ['Trails']
-     #swagger.description = 'Retrieve all trails, optionally filtered by parkId'
+     #swagger.description = 'Retrieve all trails with pagination, optionally filtered by parkId'
      #swagger.parameters['parkId'] = {
        in: 'query',
        description: 'Optional park ObjectId used to filter trails',
        required: false,
        type: 'string'
+     }
+     #swagger.parameters['page'] = {
+       in: 'query',
+       description: 'Page number (default: 1)',
+       required: false,
+       type: 'integer'
+     }
+     #swagger.parameters['limit'] = {
+       in: 'query',
+       description: 'Number of results per page (default: 10)',
+       required: false,
+       type: 'integer'
      }
   */
   try {
@@ -21,8 +33,22 @@ const getAllTrails = async (req, res) => {
       filter.parkId = req.query.parkId;
     }
 
-    const trails = await Trail.find(filter);
-    return res.status(200).json(trails);
+    const page = Math.max(1, parseInt(req.query.page) || 1);
+    const limit = Math.max(1, parseInt(req.query.limit) || 10);
+    const skip = (page - 1) * limit;
+
+    const [trails, total] = await Promise.all([
+      Trail.find(filter).skip(skip).limit(limit),
+      Trail.countDocuments(filter)
+    ]);
+
+    return res.status(200).json({
+      data: trails,
+      page,
+      limit,
+      total,
+      totalPages: Math.ceil(total / limit)
+    });
   } catch (error) {
     return res.status(500).json({
       error: error.message || "An error occurred while fetching trails."

--- a/controllers/wildlife.js
+++ b/controllers/wildlife.js
@@ -1,0 +1,214 @@
+const mongoose = require("mongoose");
+const Wildlife = require("../models/Wildlife");
+
+const getAllWildlife = async (req, res) => {
+  /* #swagger.tags = ['Wildlife']
+     #swagger.description = 'Retrieve all wildlife with pagination, optionally filtered by parkId'
+     #swagger.parameters['parkId'] = {
+       in: 'query',
+       description: 'Optional park ObjectId used to filter wildlife',
+       required: false,
+       type: 'string'
+     }
+     #swagger.parameters['page'] = {
+       in: 'query',
+       description: 'Page number (default: 1)',
+       required: false,
+       type: 'integer'
+     }
+     #swagger.parameters['limit'] = {
+       in: 'query',
+       description: 'Number of results per page (default: 10)',
+       required: false,
+       type: 'integer'
+     }
+  */
+  try {
+    const filter = {};
+
+    if (req.query.parkId) {
+      if (!mongoose.Types.ObjectId.isValid(req.query.parkId)) {
+        return res.status(400).json({ error: "Invalid parkId." });
+      }
+      filter.parkId = req.query.parkId;
+    }
+
+    const page = Math.max(1, parseInt(req.query.page) || 1);
+    const limit = Math.max(1, parseInt(req.query.limit) || 10);
+    const skip = (page - 1) * limit;
+
+    const [wildlife, total] = await Promise.all([
+      Wildlife.find(filter).skip(skip).limit(limit),
+      Wildlife.countDocuments(filter)
+    ]);
+
+    return res.status(200).json({
+      data: wildlife,
+      page,
+      limit,
+      total,
+      totalPages: Math.ceil(total / limit)
+    });
+  } catch (error) {
+    return res.status(500).json({
+      error: error.message || "An error occurred while fetching wildlife."
+    });
+  }
+};
+
+const getWildlifeById = async (req, res) => {
+  /* #swagger.tags = ['Wildlife']
+     #swagger.description = 'Retrieve a single wildlife entry by its ID'
+     #swagger.parameters['id'] = {
+       in: 'path',
+       description: 'Wildlife ObjectId',
+       required: true,
+       type: 'string'
+     }
+  */
+  try {
+    const { id } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({ error: "Invalid wildlife id." });
+    }
+
+    const animal = await Wildlife.findById(id);
+
+    if (!animal) {
+      return res.status(404).json({ error: "Wildlife not found." });
+    }
+
+    return res.status(200).json(animal);
+  } catch (error) {
+    return res.status(500).json({
+      error: error.message || "An error occurred while fetching the wildlife entry."
+    });
+  }
+};
+
+const createWildlife = async (req, res) => {
+  /* #swagger.tags = ['Wildlife']
+     #swagger.description = 'Create a new wildlife entry. Authentication required.'
+     #swagger.parameters['obj'] = {
+       in: 'body',
+       description: 'Wildlife object',
+       required: true,
+       schema: {
+         "parkId": "64f1234567890abcde654321",
+         "commonName": "American Black Bear",
+         "scientificName": "Ursus americanus",
+         "category": "mammal",
+         "description": "The American black bear is a medium-sized bear.",
+         "habitat": "Forests, mountains, and swamps",
+         "conservationStatus": "Least Concern",
+         "imageUrl": "https://example.com/black-bear.jpg"
+       }
+     }
+  */
+  try {
+    const animal = await Wildlife.create(req.body);
+    return res.status(201).json(animal);
+  } catch (error) {
+    if (error.name === "ValidationError") {
+      return res.status(400).json({ error: error.message });
+    }
+
+    if (error.name === "CastError") {
+      return res.status(400).json({ error: "Invalid data provided." });
+    }
+
+    return res.status(500).json({
+      error: error.message || "An error occurred while creating the wildlife entry."
+    });
+  }
+};
+
+const updateWildlife = async (req, res) => {
+  /* #swagger.tags = ['Wildlife']
+     #swagger.description = 'Update a wildlife entry by its ID. Authentication required.'
+     #swagger.parameters['id'] = {
+       in: 'path',
+       description: 'Wildlife ObjectId',
+       required: true,
+       type: 'string'
+     }
+     #swagger.parameters['obj'] = {
+       in: 'body',
+       description: 'Wildlife fields to update',
+       schema: {
+         "commonName": "Updated Name",
+         "conservationStatus": "Vulnerable"
+       }
+     }
+  */
+  try {
+    const { id } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({ error: "Invalid wildlife id." });
+    }
+
+    const animal = await Wildlife.findByIdAndUpdate(id, req.body, {
+      returnDocument: "after",
+      runValidators: true
+    });
+
+    if (!animal) {
+      return res.status(404).json({ error: "Wildlife not found." });
+    }
+
+    return res.status(200).json(animal);
+  } catch (error) {
+    if (error.name === "ValidationError") {
+      return res.status(400).json({ error: error.message });
+    }
+
+    if (error.name === "CastError") {
+      return res.status(400).json({ error: "Invalid data provided." });
+    }
+
+    return res.status(500).json({
+      error: error.message || "An error occurred while updating the wildlife entry."
+    });
+  }
+};
+
+const deleteWildlife = async (req, res) => {
+  /* #swagger.tags = ['Wildlife']
+     #swagger.description = 'Delete a wildlife entry by its ID. Authentication required.'
+     #swagger.parameters['id'] = {
+       in: 'path',
+       description: 'Wildlife ObjectId',
+       required: true,
+       type: 'string'
+     }
+  */
+  try {
+    const { id } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({ error: "Invalid wildlife id." });
+    }
+
+    const animal = await Wildlife.findByIdAndDelete(id);
+
+    if (!animal) {
+      return res.status(404).json({ error: "Wildlife not found." });
+    }
+
+    return res.status(200).json({ message: "Wildlife entry deleted successfully." });
+  } catch (error) {
+    return res.status(500).json({
+      error: error.message || "An error occurred while deleting the wildlife entry."
+    });
+  }
+};
+
+module.exports = {
+  getAllWildlife,
+  getWildlifeById,
+  createWildlife,
+  updateWildlife,
+  deleteWildlife
+};

--- a/routes/index.js
+++ b/routes/index.js
@@ -45,4 +45,14 @@ router.use("/trails", (req, res, next) => {
   next();
 }, require("./trails"));
 
+router.use("/reviews", (req, res, next) => {
+  // #swagger.tags = ['Reviews']
+  next();
+}, require("./reviews"));
+
+router.use("/wildlife", (req, res, next) => {
+  // #swagger.tags = ['Wildlife']
+  next();
+}, require("./wildlife"));
+
 module.exports = router;

--- a/routes/reviews.js
+++ b/routes/reviews.js
@@ -1,0 +1,14 @@
+const express = require("express");
+const router = express.Router();
+const reviewsController = require("../controllers/reviews");
+const { isAuthenticated } = require("../middleware/auth");
+const idParamRule = require("../validators/idParamValidator");
+const validate = require("../middleware/validate");
+
+router.get("/", reviewsController.getAllReviews);
+router.get("/:id", idParamRule(), validate, reviewsController.getReviewById);
+router.post("/", isAuthenticated, reviewsController.createReview);
+router.put("/:id", isAuthenticated, idParamRule(), validate, reviewsController.updateReview);
+router.delete("/:id", isAuthenticated, idParamRule(), validate, reviewsController.deleteReview);
+
+module.exports = router;

--- a/routes/wildlife.js
+++ b/routes/wildlife.js
@@ -1,0 +1,14 @@
+const express = require("express");
+const router = express.Router();
+const wildlifeController = require("../controllers/wildlife");
+const { isAuthenticated } = require("../middleware/auth");
+const idParamRule = require("../validators/idParamValidator");
+const validate = require("../middleware/validate");
+
+router.get("/", wildlifeController.getAllWildlife);
+router.get("/:id", idParamRule(), validate, wildlifeController.getWildlifeById);
+router.post("/", isAuthenticated, wildlifeController.createWildlife);
+router.put("/:id", isAuthenticated, idParamRule(), validate, wildlifeController.updateWildlife);
+router.delete("/:id", isAuthenticated, idParamRule(), validate, wildlifeController.deleteWildlife);
+
+module.exports = router;

--- a/swagger.json
+++ b/swagger.json
@@ -7,20 +7,32 @@
   },
   "host": "localhost:3000",
   "basePath": "/",
-  "tags": [],
   "schemes": [
     "http"
   ],
-  "consumes": [],
-  "produces": [],
   "paths": {
     "/parks/": {
       "get": {
         "tags": [
           "Parks"
         ],
-        "description": "Retrieve all parks",
-        "parameters": [],
+        "description": "Retrieve all parks with pagination",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number (default: 1)",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number of results per page (default: 10)",
+            "required": false,
+            "type": "integer"
+          }
+        ],
         "responses": {
           "200": {
             "description": "OK"
@@ -231,7 +243,7 @@
         "tags": [
           "Campgrounds"
         ],
-        "description": "Retrieve all campgrounds, optionally filtered by parkId",
+        "description": "Retrieve all campgrounds with pagination, optionally filtered by parkId",
         "parameters": [
           {
             "name": "parkId",
@@ -239,6 +251,20 @@
             "description": "Optional park ObjectId used to filter campgrounds",
             "required": false,
             "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number (default: 1)",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number of results per page (default: 10)",
+            "required": false,
+            "type": "integer"
           }
         ],
         "responses": {
@@ -458,7 +484,7 @@
         "tags": [
           "Adventures"
         ],
-        "description": "Retrieve all adventures, optionally filtered by parkId",
+        "description": "Retrieve all adventures with pagination, optionally filtered by parkId",
         "parameters": [
           {
             "name": "parkId",
@@ -466,6 +492,20 @@
             "description": "Optional park ObjectId used to filter adventures",
             "required": false,
             "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number (default: 1)",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number of results per page (default: 10)",
+            "required": false,
+            "type": "integer"
           }
         ],
         "responses": {
@@ -674,7 +714,7 @@
         "tags": [
           "Alerts"
         ],
-        "description": "Retrieve all alerts, optionally filtered by parkId",
+        "description": "Retrieve all alerts with pagination, optionally filtered by parkId",
         "parameters": [
           {
             "name": "parkId",
@@ -682,6 +722,20 @@
             "description": "Optional park ObjectId used to filter alerts",
             "required": false,
             "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number (default: 1)",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number of results per page (default: 10)",
+            "required": false,
+            "type": "integer"
           }
         ],
         "responses": {
@@ -884,7 +938,7 @@
         "tags": [
           "Trails"
         ],
-        "description": "Retrieve all trails, optionally filtered by parkId",
+        "description": "Retrieve all trails with pagination, optionally filtered by parkId",
         "parameters": [
           {
             "name": "parkId",
@@ -892,6 +946,20 @@
             "description": "Optional park ObjectId used to filter trails",
             "required": false,
             "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number (default: 1)",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number of results per page (default: 10)",
+            "required": false,
+            "type": "integer"
           }
         ],
         "responses": {
@@ -1096,7 +1164,442 @@
           }
         }
       }
+    },
+    "/reviews/": {
+      "get": {
+        "tags": [
+          "Reviews"
+        ],
+        "description": "Retrieve all reviews with pagination, optionally filtered by parkId",
+        "parameters": [
+          {
+            "name": "parkId",
+            "in": "query",
+            "description": "Optional park ObjectId used to filter reviews",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number (default: 1)",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number of results per page (default: 10)",
+            "required": false,
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Reviews"
+        ],
+        "description": "Create a new review. Authentication required.",
+        "parameters": [
+          {
+            "name": "obj",
+            "in": "body",
+            "description": "Review object",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "parkId": {
+                  "type": "string",
+                  "example": "64f1234567890abcde654321"
+                },
+                "userId": {
+                  "type": "string",
+                  "example": "github12345"
+                },
+                "rating": {
+                  "type": "number",
+                  "example": 5
+                },
+                "title": {
+                  "type": "string",
+                  "example": "Breathtaking Views"
+                },
+                "comment": {
+                  "type": "string",
+                  "example": "One of the most beautiful places I have ever visited."
+                },
+                "visitDate": {
+                  "type": "string",
+                  "example": "2025-07-20"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/reviews/{id}": {
+      "get": {
+        "tags": [
+          "Reviews"
+        ],
+        "description": "Retrieve a single review by its ID",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Review ObjectId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Reviews"
+        ],
+        "description": "Update a review by its ID. Authentication required.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Review ObjectId"
+          },
+          {
+            "name": "obj",
+            "in": "body",
+            "description": "Review fields to update",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "rating": {
+                  "type": "number",
+                  "example": 4
+                },
+                "title": {
+                  "type": "string",
+                  "example": "Updated Title"
+                },
+                "comment": {
+                  "type": "string",
+                  "example": "Updated comment."
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Reviews"
+        ],
+        "description": "Delete a review by its ID. Authentication required.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Review ObjectId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/wildlife/": {
+      "get": {
+        "tags": [
+          "Wildlife"
+        ],
+        "description": "Retrieve all wildlife with pagination, optionally filtered by parkId",
+        "parameters": [
+          {
+            "name": "parkId",
+            "in": "query",
+            "description": "Optional park ObjectId used to filter wildlife",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number (default: 1)",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number of results per page (default: 10)",
+            "required": false,
+            "type": "integer"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Wildlife"
+        ],
+        "description": "Create a new wildlife entry. Authentication required.",
+        "parameters": [
+          {
+            "name": "obj",
+            "in": "body",
+            "description": "Wildlife object",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "parkId": {
+                  "type": "string",
+                  "example": "64f1234567890abcde654321"
+                },
+                "commonName": {
+                  "type": "string",
+                  "example": "American Black Bear"
+                },
+                "scientificName": {
+                  "type": "string",
+                  "example": "Ursus americanus"
+                },
+                "category": {
+                  "type": "string",
+                  "example": "mammal"
+                },
+                "description": {
+                  "type": "string",
+                  "example": "The American black bear is a medium-sized bear."
+                },
+                "habitat": {
+                  "type": "string",
+                  "example": "Forests, mountains, and swamps"
+                },
+                "conservationStatus": {
+                  "type": "string",
+                  "example": "Least Concern"
+                },
+                "imageUrl": {
+                  "type": "string",
+                  "example": "https://example.com/black-bear.jpg"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/wildlife/{id}": {
+      "get": {
+        "tags": [
+          "Wildlife"
+        ],
+        "description": "Retrieve a single wildlife entry by its ID",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Wildlife ObjectId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Wildlife"
+        ],
+        "description": "Update a wildlife entry by its ID. Authentication required.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Wildlife ObjectId"
+          },
+          {
+            "name": "obj",
+            "in": "body",
+            "description": "Wildlife fields to update",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "commonName": {
+                  "type": "string",
+                  "example": "Updated Name"
+                },
+                "conservationStatus": {
+                  "type": "string",
+                  "example": "Vulnerable"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Wildlife"
+        ],
+        "description": "Delete a wildlife entry by its ID. Authentication required.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Wildlife ObjectId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
     }
-  },
-  "definitions": {}
+  }
 }


### PR DESCRIPTION
Add page and limit query parameters (default page=1, limit=10) to all seven collection endpoints: parks, adventures, alerts, campgrounds, trails, reviews, and wildlife. Each endpoint now uses Mongoose .skip() and .limit(), returns total via countDocuments(), and wraps results in { data, page, limit, total, totalPages }. Also adds full CRUD controllers and routes for reviews and wildlife, which previously had models but no endpoints. Swagger docs updated.