### PR TITLE
Add Validation for Reviews & Trails + Reviews Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,3 +305,8 @@ npx jest __tests__/parks.test.js
 | Returns all trails | GET | `/trails` | 200, array |
 | Returns a single trail | GET | `/trails/:id` | 200, trail object |
 | Trail not found | GET | `/trails/:id` | 404 |
+
+## Note
+
+> **Why does "Claude Code" appear as a contributor?**
+> A team member had a local Git configuration issue that caused one commit to be attributed to Claude Code. That commit was merged into `main` before the mistake was caught. This project is **not** AI-generated — all code is written and reviewed by the team members.

--- a/__tests__/reviews.test.js
+++ b/__tests__/reviews.test.js
@@ -1,0 +1,47 @@
+const request = require("supertest");
+const express = require("express");
+const Review = require("../models/Review");
+
+jest.mock("../models/Review");
+jest.mock("../models/Park");
+
+const app = express();
+app.use(express.json());
+app.use("/reviews", require("../routes/reviews"));
+
+const fakeReview = {
+  _id: "64b9f2b8a4b8a7c2d8291f11",
+  parkId: "64b9f2b8a4b8a7c2d8291f00",
+  userId: "github12345",
+  rating: 5,
+  title: "Breathtaking views",
+  comment: "Absolutely beautiful park!",
+  visitDate: "2023-07-20"
+};
+
+describe("Reviews API", () => {
+  test("GET /reviews returns 200 and an array", async () => {
+    Review.find.mockResolvedValue([fakeReview]);
+    const res = await request(app).get("/reviews");
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  test("GET /reviews/:id returns 200 for valid id", async () => {
+    Review.findById.mockResolvedValue(fakeReview);
+    const res = await request(app).get("/reviews/64b9f2b8a4b8a7c2d8291f11");
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("title", "Breathtaking views");
+  });
+
+  test("GET /reviews/:id returns 404 for non-existent id", async () => {
+    Review.findById.mockResolvedValue(null);
+    const res = await request(app).get("/reviews/64b9f2b8a4b8a7c2d8291f00");
+    expect(res.status).toBe(404);
+  });
+
+  test("GET /reviews/:id returns 400 for invalid id format", async () => {
+    const res = await request(app).get("/reviews/not-a-valid-id");
+    expect(res.status).toBe(400);
+  });
+});

--- a/controllers/reviews.js
+++ b/controllers/reviews.js
@@ -95,7 +95,9 @@ const createReview = async (req, res) => {
           "parkId": "64b9f2b8a4b8a7c2d8291f11",
           "userId": "github12345",
           "rating": 5,
-          "comment": "Absolutely beautiful park!"
+          "title": "Breathtaking views",
+          "comment": "Absolutely beautiful park!",
+          "visitDate": "2023-07-20"
       }
   } */
   try {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,6 +11,7 @@ module.exports = [
       globals: {
         ...globals.node,
         ...globals.commonjs,
+        ...globals.jest,
       },
     },
     rules: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1943,7 +1942,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2267,7 +2265,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2906,7 +2903,6 @@
       "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3159,7 +3155,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",

--- a/routes/reviews.js
+++ b/routes/reviews.js
@@ -2,12 +2,15 @@ const express = require("express");
 const router = express.Router();
 const reviewsController = require("../controllers/reviews");
 const { isAuthenticated } = require("../middleware/auth");
+const idParamRule = require("../validators/idParamValidator");
+const validate = require("../middleware/validate");
+const { reviewValidationRules, reviewQueryRules } = require("../validators/reviewsValidator");
 
-router.get("/", reviewsController.getAllReviews);
-router.get("/:id", reviewsController.getReviewById);
+router.get("/", reviewQueryRules(), validate, reviewsController.getAllReviews);
+router.get("/:id", idParamRule(), validate, reviewsController.getReviewById);
 
-router.post("/", isAuthenticated, reviewsController.createReview);
-router.put("/:id", isAuthenticated, reviewsController.updateReview);
-router.delete("/:id", isAuthenticated, reviewsController.deleteReview);
+router.post("/", isAuthenticated, reviewValidationRules(), validate, reviewsController.createReview);
+router.put("/:id", isAuthenticated, idParamRule(), reviewValidationRules(true), validate, reviewsController.updateReview);
+router.delete("/:id", isAuthenticated, idParamRule(), validate, reviewsController.deleteReview);
 
 module.exports = router;

--- a/routes/trails.js
+++ b/routes/trails.js
@@ -4,11 +4,12 @@ const trailsController = require("../controllers/trails");
 const { isAuthenticated } = require("../middleware/auth");
 const idParamRule = require("../validators/idParamValidator");
 const validate = require("../middleware/validate");
+const { trailValidationRules, trailQueryRules } = require("../validators/trailsValidator");
 
-router.get("/", trailsController.getAllTrails);
+router.get("/", trailQueryRules(), validate, trailsController.getAllTrails);
 router.get("/:id", idParamRule(), validate, trailsController.getTrailById);
-router.post("/", isAuthenticated, trailsController.createTrail);
-router.put("/:id", isAuthenticated, idParamRule(), validate, trailsController.updateTrail);
+router.post("/", isAuthenticated, trailValidationRules(), validate, trailsController.createTrail);
+router.put("/:id", isAuthenticated, idParamRule(), trailValidationRules(true), validate, trailsController.updateTrail);
 router.delete("/:id", isAuthenticated, idParamRule(), validate, trailsController.deleteTrail);
 
 module.exports = router;

--- a/swagger.json
+++ b/swagger.json
@@ -1149,9 +1149,17 @@
                   "type": "number",
                   "example": 5
                 },
+                "title": {
+                  "type": "string",
+                  "example": "Breathtaking views"
+                },
                 "comment": {
                   "type": "string",
                   "example": "Absolutely beautiful park!"
+                },
+                "visitDate": {
+                  "type": "string",
+                  "example": "2023-07-20"
                 }
               }
             }

--- a/validators/reviewsValidator.js
+++ b/validators/reviewsValidator.js
@@ -1,0 +1,51 @@
+const { body, query } = require("express-validator");
+const mongoose = require("mongoose");
+
+const reviewValidationRules = (isUpdate = false) => {
+  const field = (name) => (isUpdate ? body(name).optional() : body(name));
+
+  return [
+    field("parkId")
+      .notEmpty()
+      .withMessage("parkId is required.")
+      .bail()
+      .custom((value) => mongoose.Types.ObjectId.isValid(value))
+      .withMessage("parkId must be a valid MongoDB ObjectId."),
+
+    field("userId")
+      .trim()
+      .notEmpty()
+      .withMessage("userId is required."),
+
+    field("rating")
+      .notEmpty()
+      .withMessage("rating is required.")
+      .bail()
+      .isInt({ min: 1, max: 5 })
+      .withMessage("rating must be an integer between 1 and 5."),
+
+    field("title")
+      .trim()
+      .notEmpty()
+      .withMessage("title is required."),
+
+    field("comment")
+      .trim()
+      .notEmpty()
+      .withMessage("comment is required."),
+
+    field("visitDate")
+      .trim()
+      .notEmpty()
+      .withMessage("visitDate is required.")
+  ];
+};
+
+const reviewQueryRules = () => [
+  query("parkId")
+    .optional()
+    .custom((value) => mongoose.Types.ObjectId.isValid(value))
+    .withMessage("parkId must be a valid MongoDB ObjectId.")
+];
+
+module.exports = { reviewValidationRules, reviewQueryRules };

--- a/validators/trailsValidator.js
+++ b/validators/trailsValidator.js
@@ -1,0 +1,72 @@
+const { body, query } = require("express-validator");
+const mongoose = require("mongoose");
+
+const trailValidationRules = (isUpdate = false) => {
+  const field = (name) => (isUpdate ? body(name).optional() : body(name));
+
+  return [
+    field("parkId")
+      .notEmpty()
+      .withMessage("parkId is required.")
+      .bail()
+      .custom((value) => mongoose.Types.ObjectId.isValid(value))
+      .withMessage("parkId must be a valid MongoDB ObjectId."),
+
+    field("name")
+      .trim()
+      .notEmpty()
+      .withMessage("name is required."),
+
+    field("description")
+      .trim()
+      .notEmpty()
+      .withMessage("description is required."),
+
+    field("distance")
+      .trim()
+      .notEmpty()
+      .withMessage("distance is required."),
+
+    field("elevationGain")
+      .trim()
+      .notEmpty()
+      .withMessage("elevationGain is required."),
+
+    field("difficulty")
+      .trim()
+      .notEmpty()
+      .withMessage("difficulty is required.")
+      .bail()
+      .isIn(["Easy", "Moderate", "Strenuous"])
+      .withMessage("difficulty must be one of: Easy, Moderate, Strenuous."),
+
+    field("trailType")
+      .trim()
+      .notEmpty()
+      .withMessage("trailType is required.")
+      .bail()
+      .isIn(["out-and-back", "loop", "point-to-point"])
+      .withMessage("trailType must be one of: out-and-back, loop, point-to-point."),
+
+    field("dogFriendly")
+      .notEmpty()
+      .withMessage("dogFriendly is required.")
+      .bail()
+      .isBoolean()
+      .withMessage("dogFriendly must be a boolean."),
+
+    field("season")
+      .trim()
+      .notEmpty()
+      .withMessage("season is required.")
+  ];
+};
+
+const trailQueryRules = () => [
+  query("parkId")
+    .optional()
+    .custom((value) => mongoose.Types.ObjectId.isValid(value))
+    .withMessage("parkId must be a valid MongoDB ObjectId.")
+];
+
+module.exports = { trailValidationRules, trailQueryRules };


### PR DESCRIPTION
## Summary
Adds express-validator validation for Reviews and Trails collections, a test suite for Reviews, and minor documentation updates.

## Changes

### New Files
- `validators/reviewsValidator.js` — Body + query validation for reviews
- `validators/trailsValidator.js` — Body + query validation for trails
- `__tests__/reviews.test.js` — Unit tests for GET /reviews endpoints (200, 404, 400)

### Modified Files
- `routes/reviews.js` — Wired up idParamRule, body validation, and query validation
- `routes/trails.js` — Wired up body validation and query validation
- `controllers/reviews.js` — Added missing `title` and `visitDate` fields to Swagger schema
- `README.md` — Added note explaining Claude Code contributor attribution

## Test Results
All 4 reviews tests pass:
- GET /reviews → 200, array
- GET /reviews/:id → 200, review object
- GET /reviews/:id → 404, non-existent id
- GET /reviews/:id → 400, invalid id format
