### PR TITLE
Remove duplicate `module.exports = router;`

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -50,6 +50,3 @@ router.use("/reviews", (req, res, next) => {
   next();
 }, require("./reviews"));
 module.exports = router;
-
-
-module.exports = router;


### PR DESCRIPTION
Resolve a duplicate `module.exports = router;` line of code at the bottom of `routes/index.js`