### PR TITLE
Pa feature/wildlife crud

### DIFF
--- a/__tests__/wildlife.test.js
+++ b/__tests__/wildlife.test.js
@@ -1,0 +1,49 @@
+const request = require("supertest");
+const express = require("express");
+const Wildlife = require("../models/Wildlife");
+
+jest.mock("../models/Wildlife");
+jest.mock("../models/Park");
+
+const app = express();
+app.use(express.json());
+app.use("/wildlife", require("../routes/wildlife"));
+
+const fakeWildlife = {
+  _id: "64b9f2b8a4b8a7c2d8291f11",
+  parkId: "64b9f2b8a4b8a7c2d8291f00",
+  commonName: "Clarks Nutcracker",
+  scientificName: "Nucifraga columbiana",
+  category: "bird",
+  description: "A bird known for hoarding pine seeds.",
+  habitat: "High elevation pine forests",
+  conservationStatus: "Least Concern",
+  imageUrl: "https://example.com/bird.jpg"
+};
+
+describe("Wildlife API", () => {
+  test("GET /wildlife returns 200 and an array", async () => {
+    Wildlife.find.mockResolvedValue([fakeWildlife]);
+    const res = await request(app).get("/wildlife");
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  test("GET /wildlife/:id returns 200 for valid id", async () => {
+    Wildlife.findById.mockResolvedValue(fakeWildlife);
+    const res = await request(app).get("/wildlife/64b9f2b8a4b8a7c2d8291f11");
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("commonName", "Clarks Nutcracker");
+  });
+
+  test("GET /wildlife/:id returns 404 for non-existent id", async () => {
+    Wildlife.findById.mockResolvedValue(null);
+    const res = await request(app).get("/wildlife/64b9f2b8a4b8a7c2d8291f00");
+    expect(res.status).toBe(404);
+  });
+
+  test("GET /wildlife/:id returns 400 for invalid id format", async () => {
+    const res = await request(app).get("/wildlife/not-a-valid-id");
+    expect(res.status).toBe(400);
+  });
+});

--- a/controllers/wildlife.js
+++ b/controllers/wildlife.js
@@ -1,0 +1,250 @@
+const mongoose = require("mongoose");
+const Wildlife = require("../models/Wildlife");
+const Park = require("../models/Park");
+
+const getAllWildlife = async (req, res) => {
+  /* #swagger.tags = ['Wildlife']
+     #swagger.description = 'Retrieve all wildlife, optionally filtered by parkId'
+     #swagger.parameters['parkId'] = {
+        in: 'query',
+        description: 'Optional park ObjectId used to filter wildlife',
+        required: false,
+        type: 'string'
+     }
+  */
+  try {
+    const filter = {};
+
+    if (req.query.parkId) {
+      if (!mongoose.Types.ObjectId.isValid(req.query.parkId)) {
+        return res.status(400).json({
+          success: false,
+          message: "Invalid parkId"
+        });
+      }
+
+      filter.parkId = req.query.parkId;
+
+      const park = await Park.findById(req.query.parkId);
+      if (!park) {
+        return res.status(404).json({
+          success: false,
+          message: "Park not found"
+        });
+      }
+    }
+
+    const wildlife = await Wildlife.find(filter);
+    return res.status(200).json(wildlife);
+  } catch (error) {
+    return res.status(500).json({
+      success: false,
+      message: error.message || "Failed to retrieve wildlife"
+    });
+  }
+};
+
+const getWildlifeById = async (req, res) => {
+  /* #swagger.tags = ['Wildlife']
+     #swagger.description = 'Retrieve a single wildlife entry by its ID'
+     #swagger.parameters['id'] = {
+        in: 'path',
+        description: 'Wildlife ObjectId',
+        required: true,
+        type: 'string'
+     }
+  */
+  try {
+    const { id } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({
+        success: false,
+        message: "Invalid wildlife id"
+      });
+    }
+
+    const wildlife = await Wildlife.findById(id);
+
+    if (!wildlife) {
+      return res.status(404).json({
+        success: false,
+        message: "Wildlife not found"
+      });
+    }
+
+    return res.status(200).json(wildlife);
+  } catch (error) {
+    return res.status(500).json({
+      success: false,
+      message: error.message || "Failed to retrieve wildlife"
+    });
+  }
+};
+
+const createWildlife = async (req, res) => {
+  // #swagger.tags = ['Wildlife']
+  // #swagger.description = 'Create a new wildlife entry. Authentication required.'
+  /* #swagger.parameters['obj'] = {
+      in: 'body',
+      description: 'Wildlife object',
+      required: true,
+      schema: {
+          "parkId": "64b9f2b8a4b8a7c2d8291f11",
+          "commonName": "Clarks Nutcracker",
+          "scientificName": "Nucifraga columbiana",
+          "category": "bird",
+          "description": "A bird known for hoarding pine seeds.",
+          "habitat": "High elevation pine forests",
+          "conservationStatus": "Least Concern",
+          "imageUrl": "https://example.com/bird.jpg"
+      }
+  } */
+  try {
+    const wildlife = await Wildlife.create(req.body);
+
+    return res.status(201).json({
+      success: true,
+      message: "Wildlife created successfully",
+      wildlife
+    });
+  } catch (error) {
+    if (error.name === "ValidationError") {
+      return res.status(400).json({
+        success: false,
+        message: error.message
+      });
+    }
+
+    if (error.name === "CastError") {
+      return res.status(400).json({
+        success: false,
+        message: "Invalid data provided"
+      });
+    }
+
+    return res.status(500).json({
+      success: false,
+      message: error.message || "Failed to create wildlife"
+    });
+  }
+};
+
+const updateWildlife = async (req, res) => {
+  // #swagger.tags = ['Wildlife']
+  // #swagger.description = 'Update an existing wildlife entry by its ID. Authentication required.'
+  /* #swagger.parameters['id'] = {
+      in: 'path',
+      description: 'Wildlife ObjectId',
+      required: true,
+      type: 'string'
+  } */
+  /* #swagger.parameters['obj'] = {
+      in: 'body',
+      description: 'Wildlife fields to update',
+      schema: {
+          "commonName": "Clarks Nutcracker",
+          "conservationStatus": "Near Threatened"
+      }
+  } */
+  try {
+    const { id } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({
+        success: false,
+        message: "Invalid wildlife id"
+      });
+    }
+
+    const wildlife = await Wildlife.findByIdAndUpdate(
+      id,
+      req.body,
+      {
+        returnDocument: "after",
+        runValidators: true
+      }
+    );
+
+    if (!wildlife) {
+      return res.status(404).json({
+        success: false,
+        message: "Wildlife not found"
+      });
+    }
+
+    return res.status(200).json({
+      success: true,
+      message: "Wildlife updated successfully",
+      wildlife
+    });
+  } catch (error) {
+    if (error.name === "ValidationError") {
+      return res.status(400).json({
+        success: false,
+        message: error.message
+      });
+    }
+
+    if (error.name === "CastError") {
+      return res.status(400).json({
+        success: false,
+        message: "Invalid data provided"
+      });
+    }
+
+    return res.status(500).json({
+      success: false,
+      message: error.message || "Failed to update wildlife"
+    });
+  }
+};
+
+const deleteWildlife = async (req, res) => {
+  /* #swagger.tags = ['Wildlife']
+     #swagger.description = 'Delete a wildlife entry by its ID. Authentication required.'
+     #swagger.parameters['id'] = {
+        in: 'path',
+        description: 'Wildlife ObjectId',
+        required: true,
+        type: 'string'
+     }
+  */
+  try {
+    const { id } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({
+        success: false,
+        message: "Invalid wildlife id"
+      });
+    }
+
+    const wildlife = await Wildlife.findByIdAndDelete(id);
+
+    if (!wildlife) {
+      return res.status(404).json({
+        success: false,
+        message: "Wildlife not found"
+      });
+    }
+
+    return res.status(200).json({
+      success: true,
+      message: "Wildlife deleted successfully"
+    });
+  } catch (error) {
+    return res.status(500).json({
+      success: false,
+      message: error.message || "Failed to delete wildlife"
+    });
+  }
+};
+
+module.exports = {
+  getAllWildlife,
+  getWildlifeById,
+  createWildlife,
+  updateWildlife,
+  deleteWildlife
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -2561,6 +2561,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/content-disposition": {
@@ -3482,6 +3483,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -3592,6 +3594,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -3624,12 +3627,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
       "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -3640,6 +3645,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -3833,6 +3839,7 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -4859,34 +4866,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/json-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/json-stable-stringify-without-jsonify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -5572,6 +5551,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6350,18 +6330,6 @@
       },
       "engines": {
         "node": ">=14.18.0"
-      }
-    },
-    "node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/supports-color": {

--- a/routes/index.js
+++ b/routes/index.js
@@ -49,4 +49,10 @@ router.use("/reviews", (req, res, next) => {
   // #swagger.tags = ['Reviews']
   next();
 }, require("./reviews"));
+
+router.use("/wildlife", (req, res, next) => {
+  // #swagger.tags = ['Wildlife']
+  next();
+}, require("./wildlife"));
+
 module.exports = router;

--- a/routes/wildlife.js
+++ b/routes/wildlife.js
@@ -1,0 +1,15 @@
+const express = require("express");
+const router = express.Router();
+const wildlifeController = require("../controllers/wildlife");
+const { isAuthenticated } = require("../middleware/auth");
+const idParamRule = require("../validators/idParamValidator");
+const validate = require("../middleware/validate");
+const { wildlifeValidationRules, wildlifeQueryRules } = require("../validators/wildlifeValidator");
+
+router.get("/", wildlifeQueryRules(), validate, wildlifeController.getAllWildlife);
+router.get("/:id", idParamRule(), validate, wildlifeController.getWildlifeById);
+router.post("/", isAuthenticated, wildlifeValidationRules(), validate, wildlifeController.createWildlife);
+router.put("/:id", isAuthenticated, idParamRule(), wildlifeValidationRules(true), validate, wildlifeController.updateWildlife);
+router.delete("/:id", isAuthenticated, idParamRule(), validate, wildlifeController.deleteWildlife);
+
+module.exports = router;

--- a/swagger.json
+++ b/swagger.json
@@ -7,9 +7,12 @@
   },
   "host": "localhost:3000",
   "basePath": "/",
+  "tags": [],
   "schemes": [
     "http"
   ],
+  "consumes": [],
+  "produces": [],
   "paths": {
     "/parks/": {
       "get": {
@@ -17,6 +20,7 @@
           "Parks"
         ],
         "description": "Retrieve all parks",
+        "parameters": [],
         "responses": {
           "200": {
             "description": "OK"
@@ -1134,14 +1138,6 @@
             "in": "body",
             "description": "Review object",
             "required": true,
-            "type": "string",
-            "description": "Adventure ObjectId",
-            "example": "64f1234567890abcde123456"
-          },
-          {
-            "name": "obj",
-            "in": "body",
-            "description": "Adventure fields to update",
             "schema": {
               "type": "object",
               "properties": {
@@ -1304,6 +1300,216 @@
           }
         }
       }
+    },
+    "/wildlife/": {
+      "get": {
+        "tags": [
+          "Wildlife"
+        ],
+        "description": "Retrieve all wildlife, optionally filtered by parkId",
+        "parameters": [
+          {
+            "name": "parkId",
+            "in": "query",
+            "description": "Optional park ObjectId used to filter wildlife",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Wildlife"
+        ],
+        "description": "Create a new wildlife entry. Authentication required.",
+        "parameters": [
+          {
+            "name": "obj",
+            "in": "body",
+            "description": "Wildlife object",
+            "required": true,
+            "schema": {
+              "type": "object",
+              "properties": {
+                "parkId": {
+                  "type": "string",
+                  "example": "64b9f2b8a4b8a7c2d8291f11"
+                },
+                "commonName": {
+                  "type": "string",
+                  "example": "Clarks Nutcracker"
+                },
+                "scientificName": {
+                  "type": "string",
+                  "example": "Nucifraga columbiana"
+                },
+                "category": {
+                  "type": "string",
+                  "example": "bird"
+                },
+                "description": {
+                  "type": "string",
+                  "example": "A bird known for hoarding pine seeds."
+                },
+                "habitat": {
+                  "type": "string",
+                  "example": "High elevation pine forests"
+                },
+                "conservationStatus": {
+                  "type": "string",
+                  "example": "Least Concern"
+                },
+                "imageUrl": {
+                  "type": "string",
+                  "example": "https://example.com/bird.jpg"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
+    },
+    "/wildlife/{id}": {
+      "get": {
+        "tags": [
+          "Wildlife"
+        ],
+        "description": "Retrieve a single wildlife entry by its ID",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Wildlife ObjectId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Wildlife"
+        ],
+        "description": "Update an existing wildlife entry by its ID. Authentication required.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Wildlife ObjectId"
+          },
+          {
+            "name": "obj",
+            "in": "body",
+            "description": "Wildlife fields to update",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "commonName": {
+                  "type": "string",
+                  "example": "Clarks Nutcracker"
+                },
+                "conservationStatus": {
+                  "type": "string",
+                  "example": "Near Threatened"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Wildlife"
+        ],
+        "description": "Delete a wildlife entry by its ID. Authentication required.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Wildlife ObjectId"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        }
+      }
     }
-  }
+  },
+  "definitions": {}
 }

--- a/validators/wildlifeValidator.js
+++ b/validators/wildlifeValidator.js
@@ -1,0 +1,63 @@
+const { body, query } = require("express-validator");
+const mongoose = require("mongoose");
+
+const wildlifeValidationRules = (isUpdate = false) => {
+  const field = (name) => (isUpdate ? body(name).optional() : body(name));
+
+  return [
+    field("parkId")
+      .notEmpty()
+      .withMessage("parkId is required.")
+      .bail()
+      .custom((value) => mongoose.Types.ObjectId.isValid(value))
+      .withMessage("parkId must be a valid MongoDB ObjectId."),
+
+    field("commonName")
+      .trim()
+      .notEmpty()
+      .withMessage("commonName is required."),
+
+    field("scientificName")
+      .trim()
+      .notEmpty()
+      .withMessage("scientificName is required."),
+
+    field("category")
+      .trim()
+      .notEmpty()
+      .withMessage("category is required.")
+      .bail()
+      .isIn(["mammal", "bird", "fish", "reptile", "amphibian"])
+      .withMessage("category must be one of: mammal, bird, fish, reptile, amphibian."),
+
+    field("description")
+      .trim()
+      .notEmpty()
+      .withMessage("description is required."),
+
+    field("habitat")
+      .trim()
+      .notEmpty()
+      .withMessage("habitat is required."),
+
+    field("conservationStatus")
+      .trim()
+      .notEmpty()
+      .withMessage("conservationStatus is required."),
+
+    body("imageUrl")
+      .optional({ values: "falsy" })
+      .trim()
+      .isURL()
+      .withMessage("imageUrl must be a valid URL.")
+  ];
+};
+
+const wildlifeQueryRules = () => [
+  query("parkId")
+    .optional()
+    .custom((value) => mongoose.Types.ObjectId.isValid(value))
+    .withMessage("parkId must be a valid MongoDB ObjectId.")
+];
+
+module.exports = { wildlifeValidationRules, wildlifeQueryRules };


### PR DESCRIPTION
## Summary
Implements full CRUD operations for the Wildlife collection with validation, Swagger documentation, and unit tests.

## New Files
- **`controllers/wildlife.js`** — Full CRUD controller with inline ID/parkId validation, park existence check on filtered queries, consistent `{ success, message }` response format, and Swagger parameter annotations
- **`validators/wildlifeValidator.js`** — Body validation (parkId as ObjectId, category enum, optional imageUrl as URL) and query validation for optional parkId filtering
- **`routes/wildlife.js`** — All 5 routes wired with validation; GET routes are public, POST/PUT/DELETE require authentication
- **`__tests__/wildlife.test.js`** — Unit tests for GET endpoints (200, 404, 400)

## Modified Files
- **`routes/index.js`** — Registered `/wildlife` route
- **`swagger.json`** — Regenerated with wildlife endpoints

## Route Summary
| Method | Route | Auth | Description |
|---|---|---|---|
| GET | `/wildlife` | Public | List all, optional `?parkId=` filter |
| GET | `/wildlife/:id` | Public | Get by ID |
| POST | `/wildlife` | 🔒 | Create new wildlife entry |
| PUT | `/wildlife/:id` | 🔒 | Update wildlife entry |
| DELETE | `/wildlife/:id` | 🔒 | Delete wildlife entry |

## Test Results
All 4 wildlife tests pass:
- GET /wildlife → 200, array
- GET /wildlife/:id → 200, wildlife object
- GET /wildlife/:id → 404, non-existent id
- GET /wildlife/:id → 400, invalid id format
